### PR TITLE
Add python version classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,7 @@ setup(name="editdistance",
       classifiers=[
           'License :: OSI Approved :: MIT License',
           'Programming Language :: Python',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3',
       ]
       )


### PR DESCRIPTION
Make it easy to pragmatically determine this supports python3 via
https://github.com/brettcannon/caniusepython3.

When migrating a large code base it's nice to be to automatically check the status of dependencies (see https://docs.python.org/3/howto/pyporting.html)