### PR TITLE
Update the license declaration to the current pyproject.toml standards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 dependencies = []
 requires-python = ">=3.8"
 readme = "README.md"
-license = {text = "MIT"}
+license = "MIT"
 
 [project.urls]
 Homepage = "https://github.com/roy-ht/editdistance"


### PR DESCRIPTION
Following the guidelines in
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license

This change resolves this warning produces while trying to install editdistance:
```
  C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-bmp4on9m\normal\Lib\site-packages\setuptools\config\_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
  !!
  
          ********************************************************************************
          Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).
  
          By 2026-Feb-18, you need to update your project and remove deprecated calls
          or your builds will no longer be supported.
  
          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************
```

(Although unfortunately it does not fix #116--I have not figured that one out.) 